### PR TITLE
fix zh language keyword

### DIFF
--- a/plugin/Translator.py
+++ b/plugin/Translator.py
@@ -66,7 +66,10 @@ class GoogTranslate(FlowLauncher):
                     query = query[5:]
                 else:
                     from_language = 'auto'
-                    to_language = 'en'
+                    if query.encode().isalpha():
+                        to_language = 'cn'
+                    else:
+                        to_language = 'en'
 
                 from_language = adapt_zh(from_language)
                 to_language = adapt_zh(to_language)

--- a/plugin/Translator.py
+++ b/plugin/Translator.py
@@ -37,6 +37,11 @@ def copy2clip(txt):
     cmd = 'echo '+txt.strip()+'|clip'
     return subprocess.check_call(cmd, shell=True)
 
+def adapt_zh(language):
+    return {
+        "cn": "zh-CN",
+        "tw": "zh-TW",
+    }.get(language, language)
 
 class GoogTranslate(FlowLauncher):
 
@@ -62,6 +67,9 @@ class GoogTranslate(FlowLauncher):
                 else:
                     from_language = 'auto'
                     to_language = 'en'
+
+                from_language = adapt_zh(from_language)
+                to_language = adapt_zh(to_language)
 
                 translation = translate(
                     query, to_language, from_language, "200")


### PR DESCRIPTION
Chinese language keyword is `zh-CN` and `zh-TW`, which is not 2-character-keyword. So I define a function to adapt it.
BTW there are some other language keywords are more than 2 characters, such as `mni-Mtei`.
But input the long keyword manually is inconvenient. I have no idea how to improve it. Maybe user should set a default language keyword?