### PR TITLE
Update dependency installation in Publish Release workflow to use PyYAML

### DIFF
--- a/.github/workflows/Publish Release.yml
+++ b/.github/workflows/Publish Release.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install flowlauncher yaml -t ./lib
+          pip install flowlauncher PyYAML -t ./lib
           zip -r Flow.Launcher.Plugin.GoogleTranslate.zip . -x '*.git*'
       - name: Publish
         if: success()


### PR DESCRIPTION
I renamed the yaml package to the PyYAML which is the actual package name and was causing the Release Action to fail.
please run the Release action once you've merged the PR to create the new .zip file and update the Flow Plugin Store.